### PR TITLE
fix: Dashboard Gateway 异常 + mcp-bridge 不可达 + 用量页面 500

### DIFF
--- a/scripts/fix-sqlite3-arch.sh
+++ b/scripts/fix-sqlite3-arch.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# fix-sqlite3-arch.sh
+# 修复 better-sqlite3 原生二进制架构不匹配问题
+# 场景：Dashboard 在 arm64 机器 build，部署到 x86_64 Mac mini
+# 症状：/api/usage/history, /api/usage/sample, /api/usage/cli-history 返回 500
+#       dlopen(...better_sqlite3.node) incompatible architecture (have arm64, need x86_64h)
+
+set -euo pipefail
+
+DASHBOARD_DIR="${1:-/Users/apollos/projects/infra-dashboard}"
+
+echo "检查当前架构..."
+ARCH=$(uname -m)
+SQLITE_NODE="$DASHBOARD_DIR/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+
+if [ ! -f "$SQLITE_NODE" ]; then
+  echo "❌ better_sqlite3.node 不存在: $SQLITE_NODE"
+  exit 1
+fi
+
+CURRENT=$(file "$SQLITE_NODE" | grep -o 'arm64\|x86_64' | head -1)
+echo "系统架构: $ARCH | better-sqlite3 架构: $CURRENT"
+
+if [ "$CURRENT" = "$ARCH" ]; then
+  echo "✅ 架构匹配，无需修复"
+  exit 0
+fi
+
+echo "⚠️ 架构不匹配，重新编译..."
+cd "$DASHBOARD_DIR/node_modules/better-sqlite3"
+npm run build-release
+
+NEW_ARCH=$(file "$SQLITE_NODE" | grep -o 'arm64\|x86_64' | head -1)
+echo "✅ 编译完成: $NEW_ARCH"
+
+echo "重启 Dashboard..."
+launchctl bootout "gui/$(id -u)/com.openclaw.infra-dashboard" 2>/dev/null || true
+sleep 2
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.openclaw.infra-dashboard.plist 2>/dev/null || true
+echo "✅ Done"

--- a/scripts/launchagents/com.openclaw.infra-dashboard.plist
+++ b/scripts/launchagents/com.openclaw.infra-dashboard.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.openclaw.infra-dashboard</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/node</string>
+        <string>/Users/apollos/projects/infra-dashboard/server.js</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>/Users/apollos/projects/infra-dashboard</string>
+    <key>StandardOutPath</key>
+    <string>/Users/apollos/.openclaw/logs/dashboard.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/apollos/.openclaw/logs/dashboard.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/apollos/.local/bin:/Users/apollos/.npm-global/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/apollos</string>
+        <key>USER</key>
+        <string>apollos</string>
+        <key>LANG</key>
+        <string>en_US.UTF-8</string>
+        <key>PORT</key>
+        <string>3001</string>
+        <key>DASHBOARD_TOKEN</key>
+        <string>0000</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/launchagents/com.openclaw.mcp-bridge.plist
+++ b/scripts/launchagents/com.openclaw.mcp-bridge.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.openclaw.mcp-bridge</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/apollos/clawd/mcp-bridge/.venv/bin/python</string>
+        <string>/Users/apollos/clawd/mcp-bridge/server.py</string>
+        <string>--sse</string>
+        <string>--port</string>
+        <string>9100</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>/Users/apollos/clawd/mcp-bridge</string>
+    <key>StandardOutPath</key>
+    <string>/Users/apollos/.openclaw/logs/mcp-bridge.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/apollos/.openclaw/logs/mcp-bridge.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/apollos/.local/bin:/Users/apollos/.npm-global/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/apollos</string>
+        <key>OPENCLAW_WORKSPACE</key>
+        <string>/Users/apollos/clawd</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/openclaw-cached-wrapper.sh
+++ b/scripts/openclaw-cached-wrapper.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+REAL="/Users/apollos/.npm-global/bin/openclaw"
+CACHE="/tmp/openclaw-status-cache.json"
+MAX_AGE=30
+
+# 只拦截 "status --json" 调用
+if [ "$1" = "status" ] && [ "$2" = "--json" ]; then
+  if [ -f "$CACHE" ]; then
+    age=$(($(date +%s) - $(stat -f%m "$CACHE" 2>/dev/null || echo 0)))
+    if [ "$age" -lt "$MAX_AGE" ]; then
+      cat "$CACHE"
+      exit 0
+    fi
+  fi
+  # 缓存过期，重新获取
+  "$REAL" status --json 2>/dev/null > "${CACHE}.tmp" && mv "${CACHE}.tmp" "$CACHE" && cat "$CACHE"
+  exit $?
+fi
+
+# 其他命令直接透传
+exec "$REAL" "$@"


### PR DESCRIPTION
## 修复了三个问题

### 1. Dashboard Gateway 显示「异常/未知」
- **根因**：LaunchAgent PATH 缺失 ~/.npm-global/bin，找不到 openclaw；且 openclaw status --json 在 8GB 机器上耗时 ~19s，超 Dashboard 20s 超时
- **修复**：扩展 plist PATH + 补充环境变量，创建 30s 缓存 wrapper 脚本
- **文件**：scripts/launchagents/com.openclaw.infra-dashboard.plist + scripts/openclaw-cached-wrapper.sh

### 2. mcp-bridge 端口 9100 不可达
- **根因**：源码存在但从未部署（无 venv、无 LaunchAgent）
- **修复**：添加 LaunchAgent 配置（KeepAlive + SSE :9100）
- **文件**：scripts/launchagents/com.openclaw.mcp-bridge.plist

### 3. 用量页面 /usage 三个 API 返回 500
- **根因**：better-sqlite3 native binding 是 arm64，部署目标是 x86_64 Mac mini，架构不兼容
- **修复**：npm run build-release 重编译 + 一键修复脚本
- **文件**：scripts/fix-sqlite3-arch.sh

## 验证
| 项目 | 修复前 | 修复后 |
|------|--------|--------|
| Gateway 状态 | ❌ 异常 | ✅ 运行中 (2026.3.8) |
| mcp-bridge | ❌ 端口不可达 | ✅ :9100 正常 |
| /api/usage/* | ❌ 500 | ✅ 200 |